### PR TITLE
Fix eating food with zero hunger value crash

### DIFF
--- a/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java
+++ b/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java
@@ -51,7 +51,9 @@ public class ClientProxy extends CommonProxy {
     }
 
     public static void popHungerChange() {
-        hungerValues.pop();
+        if (!hungerValues.empty()) {
+            hungerValues.pop();
+        }
     }
 
     public static int getUnappliedHungerValues() {


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14033

Crash occurs when a food with zero hunger value is eaten, as a hunger value of 0 is not pushed to the hunger changes stack, but it still attempts to pop the change in the following event