### PR TITLE
Add null player check to tooltip event

### DIFF
--- a/src/main/java/ca/wescook/nutrition/events/EventTooltip.java
+++ b/src/main/java/ca/wescook/nutrition/events/EventTooltip.java
@@ -31,9 +31,14 @@ public class EventTooltip {
             if (nutrient.visible) stringJoiner.add(I18n.format("nutrient." + "nutrition" + ":" + nutrient.name));
         String nutrientString = stringJoiner.toString();
 
+        float nutritionValue;
         // Get nutrition value
-        FoodValues foodValues = AppleCoreAPI.accessor.getFoodValuesForPlayer(itemStack, event.entityPlayer);
-        float nutritionValue = NutrientUtils.calculateNutrition(foodValues, foundNutrients);
+        if (event.entityPlayer != null) {
+            FoodValues foodValues = AppleCoreAPI.accessor.getFoodValuesForPlayer(itemStack, event.entityPlayer);
+            nutritionValue = NutrientUtils.calculateNutrition(foodValues, foundNutrients);
+        } else {
+            nutritionValue = NutrientUtils.getNutrientValue(1, foundNutrients.size());
+        }
 
         // Build tooltip
         if (!nutrientString.equals("")) {


### PR DESCRIPTION
Fixes potential log spam due to NEI item loading

```java
[11:32:43] [NEI Item Loading/ERROR] [FML/]: Exception caught during firing event squeek.applecore.api.food.FoodEvent$GetPlayerFoodValues@1238fd7b:
java.lang.NullPointerException: Cannot invoke "net.minecraft.entity.player.EntityPlayer.getExtendedProperties(String)" because "player" is null
	at squeek.spiceoflife.foodtracker.FoodHistory.get(FoodHistory.java:54) ~[FoodHistory.class:?]
	at squeek.spiceoflife.foodtracker.FoodModifier.getFoodModifier(FoodModifier.java:61) ~[FoodModifier.class:?]
	at squeek.spiceoflife.foodtracker.FoodModifier.getFoodValues(FoodModifier.java:53) ~[FoodModifier.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1861_FoodModifier_getFoodValues_GetPlayerFoodValues.invoke(.dynamic) ~[?:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
	at squeek.applecore.api_impl.AppleCoreAccessorMutatorImpl.getFoodValuesForPlayer(AppleCoreAccessorMutatorImpl.java:85) ~[AppleCoreAccessorMutatorImpl.class:?]
	at ca.wescook.nutrition.events.EventTooltip.tooltipEvent(EventTooltip.java:35) ~[EventTooltip.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1820_EventTooltip_tooltipEvent_ItemTooltipEvent.invoke(.dynamic) ~[?:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
	at net.minecraftforge.event.ForgeEventFactory.onItemTooltip(ForgeEventFactory.java:169) ~[ForgeEventFactory.class:?]
	at net.minecraft.item.ItemStack.func_82840_a(ItemStack.java:626) ~[add.class:?]
	at codechicken.nei.guihook.GuiContainerManager.itemDisplayNameMultiline(GuiContainerManager.java:138) ~[GuiContainerManager.class:?]
	at codechicken.nei.guihook.GuiContainerManager.concatenatedDisplayName(GuiContainerManager.java:232) ~[GuiContainerManager.class:?]
	at codechicken.nei.api.ItemInfo.lambda$getSearchName$4(ItemInfo.java:523) ~[ItemInfo.class:?]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[?:?]
	at codechicken.nei.api.ItemInfo.getSearchName(ItemInfo.java:520) ~[ItemInfo.class:?]
	at codechicken.nei.api.ItemInfo.populateSearchMap(ItemInfo.java:170) ~[ItemInfo.class:?]
	at codechicken.nei.ItemList$1.execute(ItemList.java:236) [ItemList$1.class:?]
	at codechicken.nei.RestartableTask$1.run(RestartableTask.java:25) [RestartableTask$1.class:?]
[11:32:43] [NEI Item Loading/ERROR] [FML/]: Index: 1 Listeners:
```