### PR TITLE
Fixing vampirism degrading nutrition

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,6 +35,7 @@
  */
 dependencies {
     api("com.github.GTNewHorizons:AppleCore:3.3.0:dev") { transitive = false }
+    api(deobfCurse('witchery-69673:2234410'))
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:SpiceOfLife:2.1.6-carrot:dev")
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@
  */
 dependencies {
     api("com.github.GTNewHorizons:AppleCore:3.3.0:dev") { transitive = false }
-    api(deobfCurse('witchery-69673:2234410'))
+    compileOnlyApi(deobfCurse('witchery-69673:2234410'))
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:SpiceOfLife:2.1.6-carrot:dev")
 }

--- a/src/main/java/ca/wescook/nutrition/Nutrition.java
+++ b/src/main/java/ca/wescook/nutrition/Nutrition.java
@@ -4,6 +4,8 @@ import net.minecraftforge.common.MinecraftForge;
 
 import ca.wescook.nutrition.effects.EffectsList;
 import ca.wescook.nutrition.events.*;
+import ca.wescook.nutrition.modules.witchery.WitcheryHelper;
+import ca.wescook.nutrition.modules.witchery.events.WitcheryEventHandler;
 import ca.wescook.nutrition.network.ModPacketHandler;
 import ca.wescook.nutrition.potions.ModPotions;
 import ca.wescook.nutrition.proxy.CommonProxy;
@@ -47,6 +49,14 @@ public class Nutrition {
         // only register if allow over-eating is true
         if (Config.allowOverEating) {
             MinecraftForge.EVENT_BUS.register(new EventAllowOvereating());
+        }
+    }
+
+    @Mod.EventHandler
+    public void load(FMLInitializationEvent event) {
+        if (WitcheryHelper.isActive()) {
+            WitcheryEventHandler witcheryEventHandler = new WitcheryEventHandler();
+            MinecraftForge.EVENT_BUS.register(witcheryEventHandler);
         }
     }
 

--- a/src/main/java/ca/wescook/nutrition/data/NutrientManager.java
+++ b/src/main/java/ca/wescook/nutrition/data/NutrientManager.java
@@ -38,6 +38,14 @@ public class NutrientManager {
         nutrition.put(nutrient, value);
     }
 
+    public void vampireFloor() {
+        for (Nutrient nutrient : NutrientList.get()) {
+            if (nutrition.get(nutrient) < 50) {
+                nutrition.put(nutrient, 50f);
+            }
+        }
+    }
+
     // Update all nutrients
     public void set(Map<Nutrient, Float> nutrientData) {
         nutrition.putAll(nutrientData);

--- a/src/main/java/ca/wescook/nutrition/modules/ModHelperManager.java
+++ b/src/main/java/ca/wescook/nutrition/modules/ModHelperManager.java
@@ -1,0 +1,37 @@
+package ca.wescook.nutrition.modules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ca.wescook.nutrition.modules.witchery.WitcheryHelper;
+import ca.wescook.nutrition.utility.IModHelper;
+
+public class ModHelperManager {
+
+    private static List<IModHelper> helpers;
+
+    public static void preInit() {
+        setupHelpers();
+
+        for (IModHelper helper : helpers) {
+            helper.preInit();
+        }
+    }
+
+    public static void init() {
+        for (IModHelper helper : helpers) {
+            helper.init();
+        }
+    }
+
+    public static void postInit() {
+        for (IModHelper helper : helpers) {
+            helper.postInit();
+        }
+    }
+
+    private static void setupHelpers() {
+        helpers = new ArrayList<>();
+        helpers.add(new WitcheryHelper());
+    }
+}

--- a/src/main/java/ca/wescook/nutrition/modules/ModHelperManager.java
+++ b/src/main/java/ca/wescook/nutrition/modules/ModHelperManager.java
@@ -12,23 +12,14 @@ public class ModHelperManager {
 
     public static void preInit() {
         setupHelpers();
-
         for (IModHelper helper : helpers) {
             helper.preInit();
         }
     }
 
-    public static void init() {
-        for (IModHelper helper : helpers) {
-            helper.init();
-        }
-    }
+    public static void init() {}
 
-    public static void postInit() {
-        for (IModHelper helper : helpers) {
-            helper.postInit();
-        }
-    }
+    public static void postInit() {}
 
     private static void setupHelpers() {
         helpers = new ArrayList<>();

--- a/src/main/java/ca/wescook/nutrition/modules/ModuleConfig.java
+++ b/src/main/java/ca/wescook/nutrition/modules/ModuleConfig.java
@@ -1,0 +1,6 @@
+package ca.wescook.nutrition.modules;
+
+public class ModuleConfig {
+
+    public static boolean witcheryModuleActive = true;
+}

--- a/src/main/java/ca/wescook/nutrition/modules/witchery/WitcheryHelper.java
+++ b/src/main/java/ca/wescook/nutrition/modules/witchery/WitcheryHelper.java
@@ -1,0 +1,25 @@
+package ca.wescook.nutrition.modules.witchery;
+
+import ca.wescook.nutrition.modules.ModuleConfig;
+import ca.wescook.nutrition.utility.IModHelper;
+import cpw.mods.fml.common.Loader;
+
+public class WitcheryHelper implements IModHelper {
+
+    public static final String WITCHERY = "witchery";
+    private static boolean isWitcheryActive = false;
+
+    public static boolean isActive() {
+        return isWitcheryActive;
+    }
+
+    public void preInit() {
+        if (Loader.isModLoaded(WITCHERY) && (ModuleConfig.witcheryModuleActive)) {
+            isWitcheryActive = true;
+        }
+    }
+
+    public void init() {}
+
+    public void postInit() {}
+}

--- a/src/main/java/ca/wescook/nutrition/modules/witchery/events/WitcheryEventHandler.java
+++ b/src/main/java/ca/wescook/nutrition/modules/witchery/events/WitcheryEventHandler.java
@@ -1,0 +1,35 @@
+package ca.wescook.nutrition.modules.witchery.events;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.PlayerCapabilities;
+import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+
+import com.emoniph.witchery.common.ExtendedPlayer;
+
+import ca.wescook.nutrition.data.NutrientManager;
+import ca.wescook.nutrition.data.PlayerDataHandler;
+import ca.wescook.nutrition.modules.witchery.WitcheryHelper;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
+public class WitcheryEventHandler {
+
+    public static final PlayerCapabilities genericPlayerCapabilities = new PlayerCapabilities();
+
+    @SubscribeEvent
+    public void livingTick(LivingUpdateEvent event) {
+        if (!WitcheryHelper.isActive()) {
+            return;
+        }
+
+        if ((event.entity instanceof EntityPlayer player)) {
+            NutrientManager nutritionOld = PlayerDataHandler.getForPlayer(player); // Get old nutrition
+            NutrientManager nutritionNew = new NutrientManager(nutritionOld.get()); // Create new nutrition
+            final ExtendedPlayer prop = (ExtendedPlayer) player.getExtendedProperties("WitcheryExtendedPlayer");
+            if (prop.isVampire()) {
+                nutritionNew.vampireFloor();
+                PlayerDataHandler.setForPlayer(player, nutritionNew, true);
+            }
+        }
+    }
+
+}

--- a/src/main/java/ca/wescook/nutrition/modules/witchery/events/WitcheryEventHandler.java
+++ b/src/main/java/ca/wescook/nutrition/modules/witchery/events/WitcheryEventHandler.java
@@ -21,6 +21,10 @@ public class WitcheryEventHandler {
             return;
         }
 
+        if (!(event.entity.worldObj.isRemote)) {
+            return;
+        }
+
         if ((event.entity instanceof EntityPlayer player)) {
             final ExtendedPlayer prop = (ExtendedPlayer) player.getExtendedProperties("WitcheryExtendedPlayer");
             if (prop.isVampire()) {

--- a/src/main/java/ca/wescook/nutrition/modules/witchery/events/WitcheryEventHandler.java
+++ b/src/main/java/ca/wescook/nutrition/modules/witchery/events/WitcheryEventHandler.java
@@ -22,10 +22,10 @@ public class WitcheryEventHandler {
         }
 
         if ((event.entity instanceof EntityPlayer player)) {
-            NutrientManager nutritionOld = PlayerDataHandler.getForPlayer(player); // Get old nutrition
-            NutrientManager nutritionNew = new NutrientManager(nutritionOld.get()); // Create new nutrition
             final ExtendedPlayer prop = (ExtendedPlayer) player.getExtendedProperties("WitcheryExtendedPlayer");
             if (prop.isVampire()) {
+                NutrientManager nutritionOld = PlayerDataHandler.getForPlayer(player); // Get old nutrition
+                NutrientManager nutritionNew = new NutrientManager(nutritionOld.get()); // Create new nutrition
                 nutritionNew.vampireFloor();
                 PlayerDataHandler.setForPlayer(player, nutritionNew, true);
             }

--- a/src/main/java/ca/wescook/nutrition/proxy/CommonProxy.java
+++ b/src/main/java/ca/wescook/nutrition/proxy/CommonProxy.java
@@ -1,10 +1,23 @@
 package ca.wescook.nutrition.proxy;
 
+import ca.wescook.nutrition.modules.ModHelperManager;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 
 public class CommonProxy {
 
-    public void init(FMLInitializationEvent event) {}
+    public void preInit(FMLPreInitializationEvent event) {
+        ModHelperManager.preInit();
+    }
+
+    public void init(FMLInitializationEvent event) {
+        ModHelperManager.init();
+    }
+
+    public void postInit(FMLPostInitializationEvent event) {
+        ModHelperManager.postInit();
+    }
 
     public boolean isClient() {
         return false;

--- a/src/main/java/ca/wescook/nutrition/utility/IModHelper.java
+++ b/src/main/java/ca/wescook/nutrition/utility/IModHelper.java
@@ -1,0 +1,10 @@
+package ca.wescook.nutrition.utility;
+
+public interface IModHelper {
+
+    public void preInit();
+
+    public void init();
+
+    public void postInit();
+}


### PR DESCRIPTION
Being a vampire causes a bug with nutrition since vampirism apparently refills the hunger bar, leading to a degradation of the nutrition bars.

What this attempts to do (successfully according to Xabe in tests) is set a hard floor for vampire's nutritional bars (50%) adding a method to do so automagically that could be utilized in other methods similar to this in the future.

How this achieves it is by modifying the nutritional manager class and adding the method mentioned above, and then adding a witchery module folder containing a listener that calls this method if the player is a vampire which briefly checks if any of the player's nutritional bars are below 50, and if they are, sets them to 50.



And yes, I made sure it's an optional dep, I added the usual interface and class I use to manage that for ease in the future, given i'm sure this'll pop up again, might need to add Thaumic Horizons compat as well since it has similar features.

fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14771