### PR TITLE
Fix nutrients always stuck at 50% in singleplayer

### DIFF
--- a/src/main/java/ca/wescook/nutrition/events/EventEatFood.java
+++ b/src/main/java/ca/wescook/nutrition/events/EventEatFood.java
@@ -64,7 +64,9 @@ public class EventEatFood {
         if (!event.player.getEntityWorld().isRemote) { // Server
             PlayerDataHandler.getForPlayer(event.player)
                 .add(foundNutrients, nutritionValue);
-        } else { // Client
+        }
+
+        if (Nutrition.proxy.isClient()) { // Client
             ClientProxy.localNutrition.add(foundNutrients, nutritionValue);
             // set that food has now been eaten
             ClientProxy.popHungerChange();


### PR DESCRIPTION
## Bug

No matter which combination of foods you eat, in Single Player nutrition always converges at 50%.
This does not happen on a dedicated Server, only in Single Player.

## Steps to reproduce

Set any nutrition to below 50%, for example dairy
`/nutrition set YourName dairy 0`

Then eat something that does not have dairy, for example a blueberry smoothie.
`/hunger 1`, then eat it.

Open nutritions panel, dairy increased to 1%

Its the same with all other foods/nutrients. It also decreases any nutrients that are above 50 back down to 50.

## Version

GTNH 2.6.1 
Java 17.0.12+7
Nutrition 0.0.10

## Fix

I've dug around the codebase a bit and traced it to this PR https://github.com/GTNewHorizons/Nutrition/pull/5

The comment at https://github.com/GTNewHorizons/Nutrition/blob/master/src/main/java/ca/wescook/nutrition/events/EventEatFood.java#L20 explains how and when nutrients are supposed to normalize to 50.

The bug is caused by a check that is supposed to distinguish between client and server, but in singleplayer it's never detecting the client. I replaced it with the same check that the other event also uses.

I've tested the change in both singleplayer and multiplayer, and this fixes it.
Also tested that healing axe still normalizes the nutrients.