### PR TITLE
Fix client detection

### DIFF
--- a/src/main/java/ca/wescook/nutrition/events/EventEatFood.java
+++ b/src/main/java/ca/wescook/nutrition/events/EventEatFood.java
@@ -6,7 +6,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBucketMilk;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
 
-import ca.wescook.nutrition.Nutrition;
 import ca.wescook.nutrition.data.PlayerDataHandler;
 import ca.wescook.nutrition.effects.EffectsManager;
 import ca.wescook.nutrition.nutrients.Nutrient;
@@ -44,7 +43,7 @@ public class EventEatFood {
 
     @SubscribeEvent
     public void onFoodStatsChanged(FoodEvent.FoodStatsAddition event) {
-        if (Nutrition.proxy.isClient()) {
+        if (event.player.getEntityWorld().isRemote) { // Client
             // only run if hunger value increases, also ignoring saturation
             int hungerValue = event.foodValuesToBeAdded.hunger;
             if (hungerValue <= 0) return;
@@ -64,9 +63,7 @@ public class EventEatFood {
         if (!event.player.getEntityWorld().isRemote) { // Server
             PlayerDataHandler.getForPlayer(event.player)
                 .add(foundNutrients, nutritionValue);
-        }
-
-        if (Nutrition.proxy.isClient()) { // Client
+        } else { // Client
             ClientProxy.localNutrition.add(foundNutrients, nutritionValue);
             // set that food has now been eaten
             ClientProxy.popHungerChange();

--- a/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java
+++ b/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java
@@ -38,11 +38,6 @@ public class ClientProxy extends CommonProxy {
         }
     }
 
-    @Override
-    public boolean isClient() {
-        return true;
-    }
-
     public static void pushHungerChange(int hungerValue) {
         hungerValues.push(hungerValue);
     }

--- a/src/main/java/ca/wescook/nutrition/proxy/CommonProxy.java
+++ b/src/main/java/ca/wescook/nutrition/proxy/CommonProxy.java
@@ -18,8 +18,4 @@ public class CommonProxy {
     public void postInit(FMLPostInitializationEvent event) {
         ModHelperManager.postInit();
     }
-
-    public boolean isClient() {
-        return false;
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17546

In SP, `Nutrition.proxy.isClient()` is true on both Client Thread and Server Thread.
Therefore, at [this method](https://github.com/GTNewHorizons/Nutrition/blob/da690c7f674a606b59e46add7f606aaabcb206e6/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java#L58), `hungerValues` ​​may change between the time `hungerValues` was determined to be empty and the time it was popped.

Also, the real cause of the bug fixed in #19 was that pushHungerChange was called on both client and server, while popHungerChange was only called on the client.