### PR TITLE
unbind keybind by default

### DIFF
--- a/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java
+++ b/src/main/java/ca/wescook/nutrition/proxy/ClientProxy.java
@@ -5,6 +5,8 @@ import java.util.Stack;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.common.MinecraftForge;
 
+import org.lwjgl.input.Keyboard;
+
 import ca.wescook.nutrition.data.NutrientManager;
 import ca.wescook.nutrition.events.EventNutritionButton;
 import ca.wescook.nutrition.events.EventNutritionKey;
@@ -24,7 +26,8 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void init(FMLInitializationEvent event) {
         if (Config.enableGui) { // If GUI is enabled
-            ClientRegistry.registerKeyBinding(keyNutritionGui = new KeyBinding("key.nutrition", 49, "Nutrition"));
+            ClientRegistry
+                .registerKeyBinding(keyNutritionGui = new KeyBinding("key.nutrition", Keyboard.KEY_NONE, "Nutrition"));
             FMLCommonHandler.instance()
                 .bus()
                 .register(new EventNutritionKey());


### PR DESCRIPTION
there is literally a button in the inventory of the player to open the menu, additionally using a keybind is just wasting precious keyboard space in a modpack with so many keybinds already