### PR TITLE
Rework non-food hunger change checking

### DIFF
--- a/src/main/java/ca/wescook/nutrition/api/INutritionManager.java
+++ b/src/main/java/ca/wescook/nutrition/api/INutritionManager.java
@@ -11,6 +11,7 @@ import net.minecraft.util.MathHelper;
 
 import ca.wescook.nutrition.NutritionConfig;
 import ca.wescook.nutrition.nutrients.Nutrient;
+import ca.wescook.nutrition.nutrients.NutrientList;
 
 /**
  * Nutrition data manager. Used to access and modify nutrient values for players.<br>
@@ -46,6 +47,7 @@ public interface INutritionManager {
 
     /**
      * Set a player's single nutrient value.<br>
+     * <br>
      * If setting multiple, highly recommended to use {@link #setAll}.
      *
      * @param player   The player to update the nutrient value for.
@@ -77,8 +79,10 @@ public interface INutritionManager {
     boolean setAll(EntityPlayer player, Map<Nutrient, Float> values, boolean sync);
 
     /**
-     * Add a value to an existing nutrient.
-     * if adding to multiple nutrients, highly recommended to use {@link addAll}.
+     * Add a value to an existing nutrient.<br>
+     * <br>
+     * if adding to multiple nutrients, highly recommended to use {@link #addAll(EntityPlayer, List, float)}
+     * if some nutrients, or {@link #addAll(EntityPlayer, float)} if all nutrients.
      *
      * @param player   The player to add nutrient value to.
      * @param nutrient The nutrient to add value to.
@@ -89,6 +93,17 @@ public interface INutritionManager {
         float current = get(player, nutrient);
         float clamp = MathHelper.clamp_float(current + value, 0, 100);
         return set(player, nutrient, clamp);
+    }
+
+    /**
+     * Add a value to all nutrients.
+     *
+     * @param player The player to add nutrient value to.
+     * @param value  The amount of nutrient value to add to each nutrient.
+     * @return true if any of the player's nutrient values were changed.
+     */
+    default boolean addAll(EntityPlayer player, float value) {
+        return addAll(player, NutrientList.get(), value);
     }
 
     /**
@@ -111,8 +126,10 @@ public interface INutritionManager {
     }
 
     /**
-     * Remove some value from an existing nutrient.
-     * If removing from multiple, highly recommended to use {@link subtractAll}.
+     * Remove some value from an existing nutrient.<br>
+     * <br>
+     * If removing from multiple, highly recommended to use {@link #subtractAll(EntityPlayer, List, float)}
+     * if some nutrients, or {@link #subtractAll(EntityPlayer, float)} if all nutrients.
      *
      * @param player   The player to remove nutrient value from.
      * @param nutrient The nutrient to remove value from.
@@ -121,6 +138,17 @@ public interface INutritionManager {
      */
     default boolean subtract(EntityPlayer player, Nutrient nutrient, float value) {
         return add(player, nutrient, -value);
+    }
+
+    /**
+     * Remove a value from all provided nutrients.
+     *
+     * @param player The player to remove nutrient value from.
+     * @param value  The amount of nutrient value to remove from each nutrient.
+     * @return true if any of the player's nutrient values were changed.
+     */
+    default boolean subtractAll(EntityPlayer player, float value) {
+        return subtractAll(player, NutrientList.get(), value);
     }
 
     /**

--- a/src/main/java/ca/wescook/nutrition/api/INutritionManager.java
+++ b/src/main/java/ca/wescook/nutrition/api/INutritionManager.java
@@ -1,5 +1,7 @@
 package ca.wescook.nutrition.api;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -44,7 +46,7 @@ public interface INutritionManager {
 
     /**
      * Set a player's single nutrient value.<br>
-     * If setting multiple on the server, highly recommended to use {@link #setAll} to avoid unnecessary packets.
+     * If setting multiple, highly recommended to use {@link #setAll}.
      *
      * @param player   The player to update the nutrient value for.
      * @param nutrient The nutrient to update.
@@ -76,6 +78,7 @@ public interface INutritionManager {
 
     /**
      * Add a value to an existing nutrient.
+     * if adding to multiple nutrients, highly recommended to use {@link addAll}.
      *
      * @param player   The player to add nutrient value to.
      * @param nutrient The nutrient to add value to.
@@ -89,7 +92,27 @@ public interface INutritionManager {
     }
 
     /**
+     * Add a value to all provided nutrients.
+     *
+     * @param player    The player to add nutrient value to.
+     * @param nutrients The nutrients to add value to.
+     * @param value     The amount of nutrient value to add to each nutrient.
+     * @return true if any of the player's nutrient values were changed.
+     */
+    default boolean addAll(EntityPlayer player, List<Nutrient> nutrients, float value) {
+        if (nutrients == null || nutrients.isEmpty()) return false;
+        Map<Nutrient, Float> values = new HashMap<>();
+        for (Nutrient nutrient : nutrients) {
+            float current = get(player, nutrient);
+            float clamp = MathHelper.clamp_float(current + value, 0, 100);
+            values.put(nutrient, clamp);
+        }
+        return setAll(player, values);
+    }
+
+    /**
      * Remove some value from an existing nutrient.
+     * If removing from multiple, highly recommended to use {@link subtractAll}.
      *
      * @param player   The player to remove nutrient value from.
      * @param nutrient The nutrient to remove value from.
@@ -97,9 +120,19 @@ public interface INutritionManager {
      * @return true if the player's nutrient value was changed.
      */
     default boolean subtract(EntityPlayer player, Nutrient nutrient, float value) {
-        float current = get(player, nutrient);
-        float clamp = MathHelper.clamp_float(current - value, 0, 100);
-        return set(player, nutrient, clamp);
+        return add(player, nutrient, -value);
+    }
+
+    /**
+     * Remove a value from all provided nutrients.
+     *
+     * @param player    The player to remove nutrient value from.
+     * @param nutrients The nutrients to remove value from.
+     * @param value     The amount of nutrient value to remove from each nutrient.
+     * @return true if any of the player's nutrient values were changed.
+     */
+    default boolean subtractAll(EntityPlayer player, List<Nutrient> nutrients, float value) {
+        return addAll(player, nutrients, -value);
     }
 
     /**

--- a/src/main/java/ca/wescook/nutrition/api/NutritionManager.java
+++ b/src/main/java/ca/wescook/nutrition/api/NutritionManager.java
@@ -57,13 +57,13 @@ public final class NutritionManager implements INutritionManager {
         if (oldValue == value) return false;
         nutrients.put(player, nutrient, value);
 
-        // Pop non-food hunger change because if there is a change
-        // in the stack when this method is called, we can safely assume
-        // that this is either a normal food, or someone is handling nutrient
-        // values manually for their non-typical hunger restoring method.
-        popNonFoodHungerChange(player);
-
         if (!player.getEntityWorld().isRemote) {
+            // Pop non-food hunger change because if there is a change
+            // in the stack when this method is called, we can safely assume
+            // that this is either a normal food, or someone is handling nutrient
+            // values manually for their non-typical hunger restoring method.
+            popNonFoodHungerChange(player);
+
             SPacketNutrients.send(player);
         }
 
@@ -81,19 +81,19 @@ public final class NutritionManager implements INutritionManager {
             nutrients.put(player, entry.getKey(), entry.getValue());
         }
 
-        // Pop non-food hunger change because if there is a change
-        // in the stack when this method is called, we can safely assume
-        // that this is either a normal food, or someone is handling nutrient
-        // values manually for their non-typical hunger restoring method.
-        popNonFoodHungerChange(player);
+        if (!player.getEntityWorld().isRemote) {
+            // Pop non-food hunger change because if there is a change
+            // in the stack when this method is called, we can safely assume
+            // that this is either a normal food, or someone is handling nutrient
+            // values manually for their non-typical hunger restoring method.
+            popNonFoodHungerChange(player);
 
-        if (updated) {
-            if (sync && !player.getEntityWorld().isRemote) {
+            if (updated && sync) {
                 SPacketNutrients.send(player);
             }
-            return true;
         }
-        return false;
+
+        return updated;
     }
 
     @Override

--- a/src/main/java/ca/wescook/nutrition/api/NutritionManager.java
+++ b/src/main/java/ca/wescook/nutrition/api/NutritionManager.java
@@ -55,8 +55,14 @@ public final class NutritionManager implements INutritionManager {
     public boolean set(EntityPlayer player, Nutrient nutrient, float value) {
         float oldValue = get(player, nutrient);
         if (oldValue == value) return false;
-
         nutrients.put(player, nutrient, value);
+
+        // Pop non-food hunger change because if there is a change
+        // in the stack when this method is called, we can safely assume
+        // that this is either a normal food, or someone is handling nutrient
+        // values manually for their non-typical hunger restoring method.
+        popNonFoodHungerChange(player);
+
         if (!player.getEntityWorld().isRemote) {
             SPacketNutrients.send(player);
         }
@@ -74,6 +80,12 @@ public final class NutritionManager implements INutritionManager {
             }
             nutrients.put(player, entry.getKey(), entry.getValue());
         }
+
+        // Pop non-food hunger change because if there is a change
+        // in the stack when this method is called, we can safely assume
+        // that this is either a normal food, or someone is handling nutrient
+        // values manually for their non-typical hunger restoring method.
+        popNonFoodHungerChange(player);
 
         if (updated) {
             if (sync && !player.getEntityWorld().isRemote) {
@@ -134,7 +146,7 @@ public final class NutritionManager implements INutritionManager {
     public void popNonFoodHungerChange(EntityPlayer player) {
         Stack<Integer> stack = nonFoodNutritionChange.get(player);
         if (stack == null) return;
-        stack.pop();
+        if (!stack.empty()) stack.pop();
         nonFoodNutritionChange.put(player, stack);
     }
 

--- a/src/main/java/ca/wescook/nutrition/events/EventEatFood.java
+++ b/src/main/java/ca/wescook/nutrition/events/EventEatFood.java
@@ -59,13 +59,8 @@ public class EventEatFood {
         float nutritionValue = NutrientUtils.calculateNutrition(event.foodValues, foundNutrients);
 
         // Add to each nutrient
-        for (Nutrient nutrient : foundNutrients) {
-            NutritionManager.instance()
-                .add(event.player, nutrient, nutritionValue);
-        }
-
-        // Remove the non-food hunger value change, since we now know that this was actually food
-        ((NutritionManager) NutritionManager.instance()).popNonFoodHungerChange(event.player);
+        NutritionManager.instance()
+            .addAll(event.player, foundNutrients, nutritionValue);
     }
 
     // Handle drinking milk


### PR DESCRIPTION
## Summary
Allows for mods which modify player hunger value directly to manually set how nutrient values should be affected, while still keeping default behavior of normalizing to 50% in each nutrient. Also expands the API slightly, though this is mostly to enable this behavior.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26140


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
